### PR TITLE
Allow users check their account balance

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
 
 # API Endpoints
 
+🔐 **Authentication**
+
+Requests to authenticated endpoints are authorized through a Bearer token that should be provided in the `Authorization` HTTP header. Check the [`/api/auth/token`](#post-apiauthtoken) endpoint for further details on how to generate Bearer tokens.
+
+
 ## POST /api/auth/token
 
 Authenticates the user using `email` and `password` credentials and generates an auth token which can be used in subsequent calls to authenticated API endpoints.
@@ -25,12 +30,53 @@ Name       | Required | Type   | Description     |
 
 ### Response
 
-**Status**: `201 Success`
+**Status**: `201 Created`
 
 **Body**:
 ```json
 {
   "token":  "auth-token"
+}
+```
+
+## GET /api/accounts/:number
+
+🔐 **Authenticated**
+
+Return informations about the account such as its balance and number.
+
+### Path Parameters
+
+Name        | Required | Type   | Description        |
+------------|----------|--------|--------------------|
+`number`    | required | string | The account number |
+
+### Response
+
+When account exists.
+
+**Status**: `200 Success`
+
+**Body**:
+```json
+{
+  "account": {
+    "balance": "R$ 520.00",
+    "number": "1234"
+  }
+}
+```
+
+When account does not exist.
+
+**Status**: `404 Not Found`
+
+**Body**:
+```json
+{
+  "error": {
+    "message": "Unable to find account with number 1234."
+  }
 }
 ```
 
@@ -52,7 +98,7 @@ Name                     | Required | Type   | Description                      
 
 When all transfer validation are met.
 
-**Status**: `201 Success`
+**Status**: `201 Created`
 
 **Body**:
 ```json

--- a/config/config.exs
+++ b/config/config.exs
@@ -32,7 +32,9 @@ config :phoenix, :json_library, Jason
 config :argon2_elixir, argon2_type: 2
 
 # Configures Money library
-config :money, default_currency: :BRL
+config :money,
+  default_currency: :BRL,
+  symbol_space: true
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/lib/bank/accounts.ex
+++ b/lib/bank/accounts.ex
@@ -27,6 +27,19 @@ defmodule Bank.Accounts do
   end
 
   @doc """
+  Fetches a user account from the database, filtering by the given field.
+  """
+  @spec get_by(User.t(), atom(), any()) :: {:ok, Account.t()} | {:error, atom()}
+  def get_by(user, field, value) do
+    query = from a in Account, where: a.user_id == ^user.id and field(a, ^field) == ^value
+
+    case Repo.one(query) do
+      nil -> {:error, :not_found}
+      account -> {:ok, account}
+    end
+  end
+
+  @doc """
   Performs a deposit operation on the provided account. This operation will add a new Transaction to
   the account and then recalculate the account balance adding the amount to it. Deposit operations are
   performed with a lock in the account record to prevent issues while calculating the final account balance.

--- a/lib/bank_web/controllers/account_controller.ex
+++ b/lib/bank_web/controllers/account_controller.ex
@@ -1,0 +1,19 @@
+defmodule BankWeb.AccountController do
+  use BankWeb, :controller
+
+  alias Bank.Accounts
+
+  def show(%{assigns: %{current_user: user}} = conn, params) do
+    case Accounts.get_by(user, :number, params["number"]) do
+      {:ok, account} ->
+        conn
+        |> put_status(:ok)
+        |> render("show.json", account: account)
+
+      {:error, _} ->
+        conn
+        |> put_status(:not_found)
+        |> render("not_found.json", number: params["number"])
+    end
+  end
+end

--- a/lib/bank_web/router.ex
+++ b/lib/bank_web/router.ex
@@ -20,8 +20,7 @@ defmodule BankWeb.Router do
   scope "/api", BankWeb do
     pipe_through [:api, :ensure_authenticated]
 
-    scope "/accounts", Account do
-      post "/transfer", TransferController, :create
-    end
+    resources "/accounts", AccountController, only: [:show], param: "number"
+    post "/accounts/transfer", Account.TransferController, :create
   end
 end

--- a/lib/bank_web/views/account_view.ex
+++ b/lib/bank_web/views/account_view.ex
@@ -1,0 +1,20 @@
+defmodule BankWeb.AccountView do
+  use BankWeb, :view
+
+  def render("show.json", %{account: account}) do
+    %{
+      account: %{
+        number: account.number,
+        balance: Money.to_string(account.balance)
+      }
+    }
+  end
+
+  def render("not_found.json", %{number: number}) do
+    %{
+      error: %{
+        message: "Unable to find account with number #{number}."
+      }
+    }
+  end
+end

--- a/test/bank/accounts_test.exs
+++ b/test/bank/accounts_test.exs
@@ -50,6 +50,33 @@ defmodule Bank.AccountsTest do
     end
   end
 
+  describe "get_by/1" do
+    test "fetches an account by its number" do
+      user = UsersHelper.create_user()
+      AccountsHelper.create_account(user, 100, %{number: "1234"})
+
+      {:ok, account} = Accounts.get_by(user, :number, "1234")
+
+      assert account.balance == %Money{amount: 10_000, currency: :BRL}
+      assert account.number == "1234"
+      assert account.user_id == user.id
+    end
+
+    test "returns not found when account does not belong to user" do
+      user = UsersHelper.create_user()
+      another_user = UsersHelper.create_user(%{email: "jane.doe@test.com"})
+      AccountsHelper.create_account(another_user, 100, %{number: "1234"})
+
+      assert Accounts.get_by(user, :number, "1234") == {:error, :not_found}
+    end
+
+    test "returns not found when account does not exist" do
+      user = UsersHelper.create_user()
+
+      assert Accounts.get_by(user, :number, "1234") == {:error, :not_found}
+    end
+  end
+
   describe "deposit/2" do
     test "performs a deposit operation for the given account number" do
       account = AccountsHelper.create_account()

--- a/test/bank_web/controllers/account/transfer_controller_test.exs
+++ b/test/bank_web/controllers/account/transfer_controller_test.exs
@@ -28,7 +28,7 @@ defmodule BankWeb.Account.TransferControllerTest do
                "message" => "Successfully transferred amount to destination account.",
                "source_account_number" => source_account.number,
                "dest_account_number" => dest_account.number,
-               "amount" => "R$25.50"
+               "amount" => "R$ 25.50"
              }
     end
 

--- a/test/bank_web/controllers/account_controller_test.exs
+++ b/test/bank_web/controllers/account_controller_test.exs
@@ -1,0 +1,49 @@
+defmodule BankWeb.AccountControllerTest do
+  use BankWeb.ConnCase, async: true
+
+  alias Bank.{AccountsHelper, UsersHelper}
+
+  describe "GET - /accounts/:number" do
+    setup do
+      user = UsersHelper.create_user()
+      {:ok, user: user, conn: authenticated_conn(user.id)}
+    end
+
+    test "returns account informations", %{user: user, conn: conn} do
+      account = AccountsHelper.create_account(user, 100, %{number: "1234"})
+
+      response =
+        conn
+        |> get(Routes.account_path(conn, :show, account.number))
+        |> json_response(200)
+
+      assert response == %{
+               "account" => %{
+                 "number" => "1234",
+                 "balance" => "R$ 100.00"
+               }
+             }
+    end
+
+    test "returns not found when account does not belong to the authenticated user", %{conn: conn} do
+      other_user = UsersHelper.create_user(%{email: "jane.doe@test.com"})
+      account = AccountsHelper.create_account(other_user, 50_000, %{number: "1234"})
+
+      response =
+        conn
+        |> get(Routes.account_path(conn, :show, account.number))
+        |> json_response(404)
+
+      assert response == %{"error" => %{"message" => "Unable to find account with number 1234."}}
+    end
+
+    test "returns not found when account does not exist", %{conn: conn} do
+      response =
+        conn
+        |> get(Routes.account_path(conn, :show, "1234"))
+        |> json_response(404)
+
+      assert response == %{"error" => %{"message" => "Unable to find account with number 1234."}}
+    end
+  end
+end


### PR DESCRIPTION
 This PR allows API clients to check their account balance. For that, we created a new endpoint on the Bank API.

## GET /api/accounts/:number

🔐 **Authenticated**

Return informations about the account such as its balance and number.

### Path Parameters

Name        | Required | Type   | Description        |
------------|----------|--------|--------------------|
`number`    | required | string | The account number |

### Response

When account exists.

**Status**: `200 Success`

**Body**:
```json
{
  "account": {
    "balance": "R$ 520.00",
    "number": "1234"
  }
}
```

When account does not exist.

**Status**: `404 Not Found`

**Body**:
```json
{
  "error": {
    "message": "Unable to find account with number 1234."
  }
}
```